### PR TITLE
hal: fix warning with GCC

### DIFF
--- a/hal/dm.c
+++ b/hal/dm.c
@@ -760,7 +760,7 @@ IN PDM_ODM_T pDM_Odm
 	if (pDM_Odm->SupportICType & ODM_IC_11N_SERIES)
 		ODM_SetBBReg(pDM_Odm, ODM_REG_DBG_RPT_11N, bMaskDWord, 0x208);
 
-		Phydm_SearchPwdBLowerBound(pDM_Odm);
+	Phydm_SearchPwdBLowerBound(pDM_Odm);
 
 
 #endif /* CONFIG_ODM_ADAPTIVITY */


### PR DESCRIPTION
The indent is not correct and the build will fail with recent GCC