### PR TITLE
Fixes for 4.19-rc1

### DIFF
--- a/include/wifi.h
+++ b/include/wifi.h
@@ -812,7 +812,9 @@ struct ADDBA_request
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #define IEEE80211_MAX_AMPDU_BUF 0x40
+#endif
 
 
 /* Spatial Multiplexing Power Save Modes */

--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -461,11 +461,13 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 }
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+					, struct net_device *sb_dev
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 					, void *accel_priv
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
 				, select_queue_fallback_t fallback
-#endif
 #endif
 )
 {


### PR DESCRIPTION
Build tested (LibreELEC 9.0), but not run-time tested (no hardware).