### PR TITLE
kernel 5.0: Remove 'type' argument from access_ok() function

### DIFF
--- a/os_dep/rtw_android.c
+++ b/os_dep/rtw_android.c
@@ -384,7 +384,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)){
+#else
 	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)){
+#endif
 		DBG_871X("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
See: https://github.com/torvalds/linux/commit/96d4f267e40f9509e8a66e2b39e8b95655617693