### PR TITLE
rtl8192du: Fix builds with kernel 5.19.2

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -3821,7 +3821,7 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19, 2))
 static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev, unsigned int link_id)
 #else
 static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev)
@@ -5688,7 +5688,9 @@ void rtw_wdev_unregister(struct wireless_dev *wdev)
 	rtw_cfg80211_indicate_scan_done(adapter, _TRUE);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19, 2))
+	if (wdev->connected) {
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
 	if (wdev->links[0].client.current_bss) {
 #else
 	if (wdev->current_bss) {

--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -711,7 +711,9 @@ void rtw_unregister_netdevs(struct dvobj_priv *dvobj)
 		if (padapter->DriverState != DRIVER_DISAPPEAR) {
 #ifdef CONFIG_IOCTL_CFG80211
 			struct wireless_dev *wdev = padapter->rtw_wdev;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19, 2))
+			wdev->connected = NULL;
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
 			wdev->links[0].client.current_bss = NULL;
 #else
 			wdev->current_bss = NULL;
@@ -2288,7 +2290,9 @@ static int netdev_close(struct net_device *pnetdev)
 
 #ifdef CONFIG_IOCTL_CFG80211
 	wdev->iftype = NL80211_IFTYPE_STATION;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19, 2))
+	wdev->connected = NULL;
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
 	wdev->links[0].client.current_bss = NULL;
 #else
 	wdev->current_bss = NULL;


### PR DESCRIPTION
Hi @lwfinger - backported wireless updates to 5.19.2 broke the 5.19 compile.