### PR TITLE
os_dep: update os_intfs.c/usb_intf.c for kernel 6.8

### DIFF
--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -35,6 +35,10 @@
 #include <rtw_br_ext.h>
 #endif //CONFIG_BR_EXT
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+#define strlcpy strscpy
+#endif
+
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Realtek Wireless Lan Driver");
 MODULE_AUTHOR("Realtek Semiconductor Corp.");

--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -148,7 +148,7 @@ struct rtw_usb_drv rtl8192d_usb_drv = {
 	.usbdrv.supports_autosuspend = 1,
 	#endif
 
-	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19))
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0))
 	.usbdrv.drvwrap.driver.shutdown = rtw_dev_shutdown,
 	#else
 	.usbdrv.driver.shutdown = rtw_dev_shutdown,


### PR DESCRIPTION
This fixes build on Linux 6.8.0. Copied from https://github.com/aircrack-ng/rtl8812au/commits?author=alium